### PR TITLE
Showcase: Maven settings to build a fat JAR that executes without Lucene codec issues.

### DIFF
--- a/languagetool-commandline/pom.xml
+++ b/languagetool-commandline/pom.xml
@@ -38,26 +38,28 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin}</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathLayoutType>custom</classpathLayoutType>
-                            <!-- this artifact is used in languagetool-standalone, so adapt the path accordingly: -->
-                            <customClasspathLayout>libs/$${artifact.artifactId}$${dashClassifier?}.$${artifact.extension}</customClasspathLayout>
-                        </manifest>
-                        <manifestEntries>
-                            <!-- as we later unzip the language JARs (see languagetool-standalone's pom.xml), we need to add the top directory to the classpath: -->
-                            <Class-Path>./</Class-Path>
-                            <Main-Class>org.languagetool.commandline.Main</Main-Class>
-                            <ComponentVersion>${project.version}</ComponentVersion>
-                            <Implementation-Date>${maven.build.timestamp}</Implementation-Date>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>            
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <id>create-fat-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- add Main-Class to manifest file -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.languagetool.commandline.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <finalName>languagetool-commandline-fat</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/languagetool-commandline/pom.xml
+++ b/languagetool-commandline/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>create-fat-jar</id>
@@ -49,6 +49,10 @@
                         </goals>
                         <configuration>
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <!-- the base name of the resource bundle -->
+                                    <resource>META-INF/org/languagetool/language-module.properties</resource>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <!-- add Main-Class to manifest file -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
This is not indended to merge. Just to checkout and test and see how the codec Issue may be avoided. Probably still needs further sensible configuration to be sustainable. However, the resulting jar works.

~**Caveat:** The list of `languageClasses` from all the `META-INF/org/languagetool/language-module.properties` files collide and only one survives. In this specific version, I think it's always the English one that survives. In v5.0.1 it is arab.~

~The way I solved it locally was to merge the `languageClasses` from each language subpath into the `en` subdirectory's properties file with a find and grep command. There is probably a less hacky way of handling the `languagesClasses`, just as a side note.~

## Edit 2:
The issue with overriding `languageClasses` is fixed now too, by adding `AppendingTransformer`, which merges all `language-module.properties` files. `ServicesResourceTransformer` takes care of the Lucene Codecs.

Here is a patch that can just be applied to `v5.0.1` before running `mvn install -DskipTests` (note the newline at the end of the diff). It's also possible to just copy the shade plugin part from the pom of this branch and insert it after the JAR plugin manually.

```diff
diff --git a/languagetool-commandline/pom.xml b/languagetool-commandline/pom.xml
index 26bde734d1..16c6d4d291 100644
--- a/languagetool-commandline/pom.xml
+++ b/languagetool-commandline/pom.xml
@@ -58,6 +58,34 @@
                     </archive>
                 </configuration>
             </plugin>            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>create-fat-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <!-- the base name of the resource bundle -->
+                                    <resource>META-INF/org/languagetool/language-module.properties</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- add Main-Class to manifest file -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.languagetool.commandline.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <finalName>languagetool-commandline-fat</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

```

~**The following steps are not necessary to build the jar and just describe how I merged the languageClasses.**~

## Edit 1:
~Here is my hacky way of handling the languageClasses. For version 5.0.1, only the languageClasses from `ar` were included in the final jar. So I concatenated `languageClasses` from all language module subdirectories into `language-module.properties` of the `ar` language module. For the version of this fork repo, it would be the `en` module.~

~Again, there is probably a way to tell maven to do it, but I don't know how and don't have time right now. The following is a patch for the `language-module.properties` file. Further below I posted a step-by-step explanation how to generate such a file using shellscript yourself.~

### ~Patch file~ (now included in above patch)

### ~Instructions to create file by hand~

- ~First remove all deprecated language artifacts as well as the `all` artifact from the `pom.xml` of the `all` module. The following patch does just that:~

- ~Next run the following script:~

~The `language-module.properties` file of the specified module should now include all `languageClasses`.~